### PR TITLE
Put windows-only Ext trait behind cfg

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -3,8 +3,10 @@ use arboard::ImageData;
 use glam::Vec2;
 use image::{GenericImageView, ImageBuffer, Rgba};
 // use pixels::{Pixels, SurfaceTexture};
+#[cfg(target_os = "windows")]
+use platform::windows::IconExtWindows;
 use winit::{
-    dpi::PhysicalSize, platform::windows::IconExtWindows, window::{Icon, Window, WindowAttributes}
+    dpi::PhysicalSize, window::{Icon, Window, WindowAttributes}
 };
 
 use crate::{graphics_bundle::GraphicsBundle, graphics_impl::Graphics, Drag, Selection};


### PR DESCRIPTION
I don't think this trait is actually necessary, because it actually just compiles without it, but maybe it does some magic on Windows that I'm not aware of.

This makes it compile on my system (Arch), but doesn't seem to start on Wayland (Hyprland):

<details>
<summary>backtrace</summary>

```
thread 'main' panicked at src/main.rs:78:51:
Could not start context: Could not get primary monitor

Stack backtrace:
   0: anyhow::context::<impl anyhow::Context<T,core::convert::Infallible> for core::option::Option<T>>::with_context
             at /home/rsmet/.cargo/registry/src/index.crates.io-6f17d22bba15001f/anyhow-1.0.91/src/backtrace.rs:27:14
   1: cleave::context::AppContext::new
             at ./src/context.rs:109:23
   2: <cleave::App as winit::application::ApplicationHandler>::resumed
             at ./src/main.rs:78:23
   3: winit::event_loop::dispatch_event_for_app
             at /home/rsmet/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.30.5/src/event_loop.rs:646:27
   4: winit::event_loop::EventLoop<T>::run_app::{{closure}}
             at /home/rsmet/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.30.5/src/event_loop.rs:265:49
   5: core::ops::function::impls::<impl core::ops::function::FnMut<A> for &mut F>::call_mut
             at /rustc/f6e511eec7342f59a25f7c0534f1dbea00d01b14/library/core/src/ops/function.rs:294:13
   6: winit::platform_impl::linux::wayland::event_loop::EventLoop<T>::single_iteration
             at /home/rsmet/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.30.5/src/platform_impl/linux/wayland/event_loop/mod.rs:317:13
   7: winit::platform_impl::linux::wayland::event_loop::EventLoop<T>::pump_events
             at /home/rsmet/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.30.5/src/platform_impl/linux/wayland/event_loop/mod.rs:211:13
   8: winit::platform_impl::linux::wayland::event_loop::EventLoop<T>::run_on_demand
             at /home/rsmet/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.30.5/src/platform_impl/linux/wayland/event_loop/mod.rs:181:19
   9: winit::platform_impl::linux::EventLoop<T>::run_on_demand
             at /home/rsmet/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.30.5/src/platform_impl/linux/mod.rs:813:56
  10: winit::platform_impl::linux::EventLoop<T>::run
             at /home/rsmet/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.30.5/src/platform_impl/linux/mod.rs:806:9
  11: winit::event_loop::EventLoop<T>::run_app
             at /home/rsmet/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.30.5/src/event_loop.rs:265:9
  12: cleave::main
             at ./src/main.rs:163:5
  13: core::ops::function::FnOnce::call_once
             at /rustc/f6e511eec7342f59a25f7c0534f1dbea00d01b14/library/core/src/ops/function.rs:250:5
  14: std::sys::backtrace::__rust_begin_short_backtrace
             at /rustc/f6e511eec7342f59a25f7c0534f1dbea00d01b14/library/std/src/sys/backtrace.rs:154:18
  15: std::rt::lang_start::{{closure}}
             at /rustc/f6e511eec7342f59a25f7c0534f1dbea00d01b14/library/std/src/rt.rs:164:18
  16: core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &F>::call_once
             at /rustc/f6e511eec7342f59a25f7c0534f1dbea00d01b14/library/core/src/ops/function.rs:284:13
  17: std::panicking::try::do_call
             at /rustc/f6e511eec7342f59a25f7c0534f1dbea00d01b14/library/std/src/panicking.rs:554:40
  18: std::panicking::try
             at /rustc/f6e511eec7342f59a25f7c0534f1dbea00d01b14/library/std/src/panicking.rs:518:19
  19: std::panic::catch_unwind
             at /rustc/f6e511eec7342f59a25f7c0534f1dbea00d01b14/library/std/src/panic.rs:345:14
  20: std::rt::lang_start_internal::{{closure}}
             at /rustc/f6e511eec7342f59a25f7c0534f1dbea00d01b14/library/std/src/rt.rs:143:48
  21: std::panicking::try::do_call
             at /rustc/f6e511eec7342f59a25f7c0534f1dbea00d01b14/library/std/src/panicking.rs:554:40
  22: std::panicking::try
             at /rustc/f6e511eec7342f59a25f7c0534f1dbea00d01b14/library/std/src/panicking.rs:518:19
  23: std::panic::catch_unwind
             at /rustc/f6e511eec7342f59a25f7c0534f1dbea00d01b14/library/std/src/panic.rs:345:14
  24: std::rt::lang_start_internal
             at /rustc/f6e511eec7342f59a25f7c0534f1dbea00d01b14/library/std/src/rt.rs:143:20
  25: std::rt::lang_start
             at /rustc/f6e511eec7342f59a25f7c0534f1dbea00d01b14/library/std/src/rt.rs:163:17
  26: main
  27: <unknown>
  28: __libc_start_main
  29: _start
stack backtrace:
   0: rust_begin_unwind
             at /rustc/f6e511eec7342f59a25f7c0534f1dbea00d01b14/library/std/src/panicking.rs:662:5
   1: core::panicking::panic_fmt
             at /rustc/f6e511eec7342f59a25f7c0534f1dbea00d01b14/library/core/src/panicking.rs:74:14
   2: core::result::unwrap_failed
             at /rustc/f6e511eec7342f59a25f7c0534f1dbea00d01b14/library/core/src/result.rs:1677:5
   3: core::result::Result<T,E>::expect
             at /rustc/f6e511eec7342f59a25f7c0534f1dbea00d01b14/library/core/src/result.rs:1059:23
   4: <cleave::App as winit::application::ApplicationHandler>::resumed
             at ./src/main.rs:78:23
   5: winit::event_loop::dispatch_event_for_app
             at /home/rsmet/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.30.5/src/event_loop.rs:646:27
   6: winit::event_loop::EventLoop<T>::run_app::{{closure}}
             at /home/rsmet/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.30.5/src/event_loop.rs:265:49
   7: core::ops::function::impls::<impl core::ops::function::FnMut<A> for &mut F>::call_mut
             at /rustc/f6e511eec7342f59a25f7c0534f1dbea00d01b14/library/core/src/ops/function.rs:294:13
   8: winit::platform_impl::linux::wayland::event_loop::EventLoop<T>::single_iteration
             at /home/rsmet/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.30.5/src/platform_impl/linux/wayland/event_loop/mod.rs:317:13
   9: winit::platform_impl::linux::wayland::event_loop::EventLoop<T>::pump_events
             at /home/rsmet/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.30.5/src/platform_impl/linux/wayland/event_loop/mod.rs:211:13
  10: winit::platform_impl::linux::wayland::event_loop::EventLoop<T>::run_on_demand
             at /home/rsmet/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.30.5/src/platform_impl/linux/wayland/event_loop/mod.rs:181:19
  11: winit::platform_impl::linux::EventLoop<T>::run_on_demand
             at /home/rsmet/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.30.5/src/platform_impl/linux/mod.rs:813:56
  12: winit::platform_impl::linux::EventLoop<T>::run
             at /home/rsmet/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.30.5/src/platform_impl/linux/mod.rs:806:9
  13: winit::event_loop::EventLoop<T>::run_app
             at /home/rsmet/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.30.5/src/event_loop.rs:265:9
  14: cleave::main
             at ./src/main.rs:163:5
  15: core::ops::function::FnOnce::call_once
             at /rustc/f6e511eec7342f59a25f7c0534f1dbea00d01b14/library/core/src/ops/function.rs:250:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```
</details>